### PR TITLE
Fix unusable TypeScript typings

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,3 @@
+export * from'./lib/sparqlAlgebra';
+export * from'./lib/algebra';
 
-import translate = require('./lib/sparqlAlgebra');
-import * as Algebra from './lib/algebra';
-
-export = {
-    translate,
-    Algebra
-};

--- a/lib/sparqlAlgebra.d.ts
+++ b/lib/sparqlAlgebra.d.ts
@@ -1,4 +1,4 @@
 import { Operation } from './algebra';
 
-declare function translate (sparql: any, quads?: boolean) : Operation;
-export = translate;
+export default function translate (sparql: any, quads?: boolean) : Operation;
+


### PR DESCRIPTION
Some minor changes to the TS typings to make them usable.

The problem is that TS does not work well when mixing exports of actual things and just interfaces with `export =`.
See: https://github.com/Microsoft/TypeScript/issues/3337