### PR TITLE
RDF.js support

### DIFF
--- a/lib/algebra.ts
+++ b/lib/algebra.ts
@@ -26,6 +26,7 @@ export const types = Object.freeze({
     ONE_OR_MORE_PATH:   'OneOrMorePath',
     ORDER_BY:           'orderby',
     PATH:               'path',
+    PATTERN:            'pattern',
     PROJECT:            'project',
     REDUCED:            'reduced',
     ROW:                'row',
@@ -96,8 +97,7 @@ export interface BoundAggregate extends Aggregate
 export interface Bgp extends Operation
 {
     type: 'bgp';
-    // TODO: update to rdf js instead of own object
-    patterns: rdfjs.Quad[];
+    patterns: Pattern[];
 }
 
 export interface Distinct extends Single
@@ -127,7 +127,7 @@ export interface Graph extends Single
 export interface Group extends Single
 {
     type: 'group';
-    variables: rdfjs.Variable[];
+    expressions: ExpressionOrTerm[]; // TODO: this one might need to change
     aggregates: BoundAggregate[];
 }
 
@@ -184,6 +184,11 @@ export interface Path extends Operation
     predicate: Operation;
     object: rdfjs.Term;
     graph?: rdfjs.Term;
+}
+
+export interface Pattern extends Operation, rdfjs.Quad
+{
+    type: 'pattern';
 }
 
 export interface Project extends Single

--- a/lib/algebra.ts
+++ b/lib/algebra.ts
@@ -9,7 +9,6 @@ export const types = Object.freeze({
     BGP:                'bgp',
     DESC:               'desc',
     DISTINCT:           'distinct',
-    EXISTS:             'exists',
     EXPRESSION:         'expression',
     EXTEND:             'extend',
     FILTER:             'filter',
@@ -21,7 +20,6 @@ export const types = Object.freeze({
     LEFT_JOIN:          'leftjoin',
     LINK:               'link',
     MINUS:              'minus',
-    NOT_EXISTS:         'notexists',
     NPS:                'nps',
     ONE_OR_MORE_PATH:   'OneOrMorePath',
     ORDER_BY:           'orderby',
@@ -43,6 +41,13 @@ export const types = Object.freeze({
     ZERO_OR_ONE_PATH:   'ZeroOrOnePath',
 });
 
+export const expressionTypes = Object.freeze({
+    EXISTENCE: 'existence',
+    NAMED:     'named',
+    OPERATOR:  'operator',
+    TERM:      'term',
+});
+
 // ----------------------- ABSTRACTS -----------------------
 
 export interface Operation
@@ -61,13 +66,37 @@ export interface Double extends Operation
     right: Operation;
 }
 
-export type ExpressionOrTerm = (Expression|rdfjs.Term);
-
 export interface Expression extends Operation
 {
-    type: 'expression'
-    symbol: string;
-    args: ExpressionOrTerm[]; // TODO: could find cleaner solution
+    type: 'expression';
+    expressionType: 'existence'|'named'|'operator'|'term';
+}
+
+export interface ExistenceExpression extends Expression
+{
+    expressionType: 'existence';
+    not: boolean;
+    input: Operation;
+}
+
+export interface NamedExpression extends Expression
+{
+    expressionType: 'named';
+    name: rdfjs.NamedNode;
+    args: Expression[];
+}
+
+export interface OperatorExpression extends Expression
+{
+    expressionType: 'operator';
+    operator: string;
+    args: Expression[];
+}
+
+export interface TermExpression extends Expression
+{
+    expressionType: 'term';
+    term: rdfjs.Term;
 }
 
 
@@ -84,9 +113,9 @@ export interface Alt extends Double
 export interface Aggregate extends Operation
 {
     type: 'aggregate';
-    symbol: string;
+    aggregate: string;
     separator?: string; // used by GROUP_CONCAT
-    expression: ExpressionOrTerm;
+    expression: Expression;
 }
 
 export interface BoundAggregate extends Aggregate
@@ -109,13 +138,13 @@ export interface Extend extends Single
 {
     type: 'extend';
     variable: rdfjs.Variable;
-    expression: ExpressionOrTerm;
+    expression: Expression;
 }
 
 export interface Filter extends Single
 {
     type: 'filter';
-    expression: ExpressionOrTerm;
+    expression: Expression;
 }
 
 export interface Graph extends Single
@@ -127,7 +156,7 @@ export interface Graph extends Single
 export interface Group extends Single
 {
     type: 'group';
-    expressions: ExpressionOrTerm[]; // TODO: this one might need to change
+    expressions: Expression[]; // TODO: this one might need to change
     aggregates: BoundAggregate[];
 }
 
@@ -145,7 +174,7 @@ export interface Join extends Double
 export interface LeftJoin extends Double
 {
     type: 'leftjoin';
-    expression: ExpressionOrTerm;
+    expression: Expression;
 }
 
 export interface Link extends Operation
@@ -174,7 +203,7 @@ export interface OneOrMorePath extends Operation
 export interface OrderBy extends Single
 {
     type: 'orderby';
-    expressions: ExpressionOrTerm[];
+    expressions: Expression[];
 }
 
 export interface Path extends Operation

--- a/lib/algebra.ts
+++ b/lib/algebra.ts
@@ -1,4 +1,6 @@
 
+import * as rdfjs from "rdf-js";
+
 // TODO: add aggregates?
 // TODO: can't find a way to use these values as string types in the interfaces
 export const types = Object.freeze({
@@ -24,7 +26,6 @@ export const types = Object.freeze({
     ONE_OR_MORE_PATH:   'OneOrMorePath',
     ORDER_BY:           'orderby',
     PATH:               'path',
-    PATTERN:            'pattern',
     PROJECT:            'project',
     REDUCED:            'reduced',
     ROW:                'row',
@@ -59,12 +60,15 @@ export interface Double extends Operation
     right: Operation;
 }
 
+export type ExpressionOrTerm = (Expression|rdfjs.Term);
+
 export interface Expression extends Operation
 {
     type: 'expression'
     symbol: string;
-    args: (Expression|string)[]; // TODO: could find cleaner solution (string is needed for variables)
+    args: ExpressionOrTerm[]; // TODO: could find cleaner solution
 }
+
 
 // TODO: currently not differentiating between lists and multisets
 
@@ -81,19 +85,19 @@ export interface Aggregate extends Operation
     type: 'aggregate';
     symbol: string;
     separator?: string; // used by GROUP_CONCAT
-    expression: Expression|string; // TODO: eh... (needed for vars)
+    expression: ExpressionOrTerm;
 }
 
 export interface BoundAggregate extends Aggregate
 {
-    variable: string;
+    variable: rdfjs.Variable;
 }
 
 export interface Bgp extends Operation
 {
     type: 'bgp';
     // TODO: update to rdf js instead of own object
-    patterns: Pattern[];
+    patterns: rdfjs.Quad[];
 }
 
 export interface Distinct extends Single
@@ -104,26 +108,26 @@ export interface Distinct extends Single
 export interface Extend extends Single
 {
     type: 'extend';
-    variable: string;
-    expression: Expression;
+    variable: rdfjs.Variable;
+    expression: ExpressionOrTerm;
 }
 
 export interface Filter extends Single
 {
     type: 'filter';
-    expression: Expression;
+    expression: ExpressionOrTerm;
 }
 
 export interface Graph extends Single
 {
     type: 'graph';
-    graph: string;
+    graph: rdfjs.Term;
 }
 
 export interface Group extends Single
 {
     type: 'group';
-    variables: string[];
+    variables: rdfjs.Variable[];
     aggregates: BoundAggregate[];
 }
 
@@ -141,13 +145,13 @@ export interface Join extends Double
 export interface LeftJoin extends Double
 {
     type: 'leftjoin';
-    expression: Expression;
+    expression: ExpressionOrTerm;
 }
 
 export interface Link extends Operation
 {
     type: 'link';
-    iri: string;
+    iri: rdfjs.NamedNode;
 }
 
 export interface Minus extends Double
@@ -158,7 +162,7 @@ export interface Minus extends Double
 export interface Nps extends Operation
 {
     type: 'nps';
-    iris: string[];
+    iris: rdfjs.NamedNode[];
 }
 
 export interface OneOrMorePath extends Operation
@@ -170,22 +174,22 @@ export interface OneOrMorePath extends Operation
 export interface OrderBy extends Single
 {
     type: 'orderby';
-    expressions: Expression[];
+    expressions: ExpressionOrTerm[];
 }
 
 export interface Path extends Operation
 {
     type: 'path';
-    subject: string;
+    subject: rdfjs.Term;
     predicate: Operation;
-    object: string;
-    graph?: string;
+    object: rdfjs.Term;
+    graph?: rdfjs.Term;
 }
 
 export interface Project extends Single
 {
     type: 'project';
-    variables: String[];
+    variables: rdfjs.Variable[];
 }
 
 export interface Reduced extends Single
@@ -214,7 +218,7 @@ export interface Union extends Double
 export interface Values extends Operation
 {
     type: 'values';
-    variables: string[];
+    variables: rdfjs.Variable[];
     bindings: any[];
 }
 
@@ -228,13 +232,4 @@ export interface ZeroOrOnePath extends Operation
 {
     type: 'ZeroOrOnePath';
     path: Operation;
-}
-
-export interface Pattern extends Operation
-{
-    type: 'pattern';
-    subject: string;
-    predicate: string;
-    object: string;
-    graph?: string;
 }

--- a/lib/sparqlAlgebra.js
+++ b/lib/sparqlAlgebra.js
@@ -8,6 +8,7 @@ const N3Util = require('n3').Util;
 const SparqlParser = require('sparqljs').Parser;
 
 const Algebra = algebra.types;
+const ETypes = algebra.expressionTypes;
 
 
 // ---------------------------------- END HELPER CLASSES ----------------------------------
@@ -23,22 +24,49 @@ function createAlgebraElement (symbol, args)
     return Object.assign({type: symbol}, args);
 }
 
-function createExpression (symbol, args)
+function createExpression (symbol, type, args)
 {
     // SPARQL.js has a list as second argument for notin (and in), we don't like lists
     // TODO: unfortunately createExpression gets called multiple times hence the array check for now
     if ((symbol === 'notin' || symbol === 'in') && _.isArray(args[1]))
         args = [args[0]].concat(args[1]);
     
+    // have their own type due to being applied to a groupGraphPattern
+    if (symbol === 'exists' || symbol === 'notexists')
+    {
+        if (args.length > 1)
+            throw new Error('Expected a single argument for exists/notexists');
+        return createAlgebraElement(Algebra.EXPRESSION, { expressionType: ETypes.EXISTENCE, not: (symbol === 'notexists'), input: args[0] });
+    }
+    
+    // map all terms to TermExpressions
+    args = args ? args.map(arg =>
+    {
+        if (_.isString(arg))
+            arg = createTerm(arg);
+        if (arg.termType)
+            return createAlgebraElement(Algebra.EXPRESSION, { expressionType: ETypes.TERM, term: arg });
+        if (!arg.expressionType)
+            return translateFilters(arg); // TODO: should look into this nesting
+        return arg;
+    }) : null;
+    
     // TODO: support for known operators?
-    return createAlgebraElement('expression', {symbol, args});
+    if (type === ETypes.OPERATOR)
+        return createAlgebraElement(Algebra.EXPRESSION, { expressionType: ETypes.OPERATOR, operator: symbol, args });
+    if (type === ETypes.NAMED)
+        return createAlgebraElement(Algebra.EXPRESSION, { expressionType: ETypes.NAMED, name: createTerm(symbol), args });
+    if (type === ETypes.TERM)
+        return createAlgebraElement(Algebra.EXPRESSION, { expressionType: ETypes.TERM, term: symbol });
+    
+    throw new Error('Invalid type: ' + type);
 }
 
-function createAggregate (symbol, input)
+function createAggregate (aggregate, input)
 {
     if (_.isArray(input))
         input = input[0];
-    return createAlgebraElement('aggregate', {symbol, expression: input});
+    return createAlgebraElement(Algebra.AGGREGATE, {aggregate, expression: input});
 }
 
 function createTriple (subject, predicate, object)
@@ -110,6 +138,7 @@ function translate (sparql, quads)
     let group = { type: 'group', patterns: sparql.where };
     let vars = inScopeVariables(group);
     let res = translateGraphPattern(group);
+    
     res = simplify(res);
     res = translateAggregates(sparql, res, vars);
     res = toRdfJs(res);
@@ -221,7 +250,7 @@ function translateGraphPattern (thingy)
     
     // update expressions to algebra format (done here since they are used in both filters and binds)
     if (thingy.type === 'operation')
-        thingy = createExpression(thingy.operator, thingy.args);
+        thingy = createExpression(thingy.operator, ETypes.OPERATOR, thingy.args);
     
     // 18.2.2.1
     // already done by sparql parser
@@ -518,7 +547,7 @@ function accumulateGroupGraphPattern (G, E)
         G = createAlgebraElement(Algebra.MINUS, { left: G, right: E.patterns[0] });
     }
     else if (E.type === 'bind')
-        G = createAlgebraElement(Algebra.EXTEND, { input: G, variable: E.variable, expression: E.expression });
+        G = createAlgebraElement(Algebra.EXTEND, { input: G, variable: E.variable, expression: translateFilters(E.expression) });
     else
         G = createAlgebraElement(Algebra.JOIN, { left: G, right: E });
     
@@ -559,17 +588,18 @@ function translateFilters (filterExpressions)
     
     filterExpressions = filterExpressions.map(exp =>
     {
-        if (_.isString(exp))
+        // TODO: investigate when this happens
+        if (exp.expressionType)
             return exp;
-        if (exp.symbol)
-            return createExpression(exp.symbol, exp.args);
+        if (_.isString(exp))
+            return createExpression(exp, ETypes.TERM);
         if (exp.function)
-            return createExpression(exp.function, exp.args);
+            return createExpression(exp.function, ETypes.NAMED, exp.args);
         if (exp.operator)
-            return createExpression(exp.operator, exp.args);
+            return createExpression(exp.operator, ETypes.OPERATOR, exp.args);
     });
     
-    return filterExpressions.reduce((acc, val) => createExpression('&&', [acc, val]));
+    return filterExpressions.reduce((acc, val) => createExpression('&&', ETypes.OPERATOR, [acc, val]));
 }
 
 // ---------------------------------- TRANSLATE AGGREGATES ----------------------------------
@@ -645,7 +675,7 @@ function translateAggregates (query, parsed, variables)
     
     // TODO: Jena simplifies by having a list of extends
     for (let v of E)
-        res = createAlgebraElement(Algebra.EXTEND, { input: res, variable: v.variable, expression: v.expression });
+        res = createAlgebraElement(Algebra.EXTEND, { input: res, variable: v.variable, expression: translateFilters(v.expression) });
     
     // 18.2.5
     //p = createAlgebraElement('tolist', [p]);
@@ -756,17 +786,10 @@ function translateExpressionsOperations(thingy)
     
     if (_.isString(thingy))
         return thingy;
-    
-    // TODO: different types for operation and functionCall
-    if (thingy.type === 'operation' && thingy.operator)
-        return createExpression(thingy.operator, thingy.args.map(subthingy => translateExpressionsOperations(subthingy)));
-    
-    if (thingy.type === 'functionCall' && thingy.function)
-        return createExpression(thingy.function, thingy.args.map(subthingy => translateExpressionsOperations(subthingy)));
         
     if (thingy.type === 'aggregate' && thingy.aggregation)
     {
-        let A = createAggregate(thingy.aggregation, [ translateExpressionsOperations(thingy.expression) ]);
+        let A = createAggregate(thingy.aggregation, [ translateFilters(thingy.expression) ]);
         // TODO: put this in object somewhere
         // this is specifically for group_concat
         if (thingy.separator && thingy.separator !== ' ')
@@ -780,10 +803,10 @@ function translateExpressionsOperations(thingy)
     }
     
     if (thingy.descending && !thingy.type)
-        return createExpression(Algebra.DESC, [ translateExpressionsOperations(thingy.expression) ]);
+        return createExpression(Algebra.DESC, ETypes.OPERATOR, [ translateFilters(thingy.expression) ]);
     
     if (thingy.expression && !thingy.type)
-        return translateExpressionsOperations(thingy.expression);
+        return translateFilters(thingy.expression);
     
     if (_.isArray(thingy))
         return thingy.map(subthingy => translateExpressionsOperations(subthingy));
@@ -795,7 +818,6 @@ function translateExpressionsOperations(thingy)
 }
 // ---------------------------------- ADD RDF.JS ----------------------------------
 
-// at this point the only remaining fields that can have a string are `type`, `symbol` (for expressions) and `separator` (damn you group_concat)
 function toRdfJs(thingy)
 {
     if (_.isString(thingy))
@@ -810,7 +832,7 @@ function toRdfJs(thingy)
     
     for (let key of Object.keys(thingy))
     {
-        if (key === 'type' || key === 'symbol' || key === 'separator')
+        if (key === 'type' || key === 'aggregate' || key === 'operator' || key === 'expressionType' || key === 'separator')
             continue;
         thingy[key] = toRdfJs(thingy[key]);
     }

--- a/lib/sparqlAlgebra.js
+++ b/lib/sparqlAlgebra.js
@@ -3,8 +3,9 @@
  */
 
 const _ = require('lodash');
-const SparqlParser = require('sparqljs').Parser;
 const algebra = require('./algebra');
+const N3Util = require('n3').Util;
+const SparqlParser = require('sparqljs').Parser;
 
 const Algebra = algebra.types;
 
@@ -15,6 +16,7 @@ const Algebra = algebra.types;
 let variables = {};
 let varCount = 0;
 let useQuads = false;
+let defaultGraph = { termType: 'DefaultGraph', value: '' };
 
 function createAlgebraElement (symbol, args)
 {
@@ -23,6 +25,11 @@ function createAlgebraElement (symbol, args)
 
 function createExpression (symbol, args)
 {
+    // SPARQL.js has a list as second argument for notin (and in), we don't like lists
+    // TODO: unfortunately createExpression gets called multiple times hence the array check for now
+    if ((symbol === 'notin' || symbol === 'in') && _.isArray(args[1]))
+        args = [args[0]].concat(args[1]);
+    
     // TODO: support for known operators?
     return createAlgebraElement('expression', {symbol, args});
 }
@@ -36,9 +43,6 @@ function createAggregate (symbol, input)
 
 function createTriple (subject, predicate, object)
 {
-    if (subject.type)
-        throw new Error ('Input is already an object');
-    
     // first parameter is a triple object
     if (subject.subject && subject.predicate && subject.object)
     {
@@ -48,9 +52,35 @@ function createTriple (subject, predicate, object)
     }
     
     if (predicate.type)
-        return createAlgebraElement(Algebra.PATH, {subject, predicate, object});
+        return createAlgebraElement(Algebra.PATH, {subject: createTerm(subject), predicate, object: createTerm(object), graph: defaultGraph});
     
-    return createAlgebraElement(Algebra.PATTERN, {subject, predicate, object});
+    return createAlgebraElement(Algebra.PATTERN, {subject: createTerm(subject), predicate: createTerm(predicate), object: createTerm(object), graph: defaultGraph});
+}
+
+function createTerm (str)
+{
+    if (str.termType)
+        return str;
+    
+    if (str[0] === '?')
+        return { termType: 'Variable', value: str.substring(1) };
+    if (str.startsWith('_:'))
+        return { termType: 'BlankNode', value: str.substring(3) };
+    if (N3Util.isLiteral(str))
+    {
+        let literal = { termType: 'Literal', value: N3Util.getLiteralValue(str) };
+        let lang = N3Util.getLiteralLanguage(str);
+        if (lang && lang.length > 0)
+            literal.language = lang;
+        else
+        {
+            let type = N3Util.getLiteralType(str);
+            if (type && type.length > 0)
+                literal.datatype = createTerm(type);
+        }
+        return literal;
+    }
+    return { termType: 'NamedNode', value: str };
 }
 
 // generate an unused variable name
@@ -82,6 +112,7 @@ function translate (sparql, quads)
     let res = translateGraphPattern(group);
     res = simplify(res);
     res = translateAggregates(sparql, res, vars);
+    res = toRdfJs(res);
     return res;
 }
 
@@ -282,7 +313,7 @@ function translateGraphPattern (thingy)
 // 18.2.2.8
 function simplify (thingy)
 {
-    if (_.isString(thingy) || _.isBoolean(thingy) || _.isInteger(thingy))
+    if (_.isString(thingy) || _.isBoolean(thingy) || _.isInteger(thingy) || thingy.termType)
         return thingy;
     if (_.isArray(thingy))
         return thingy.map(subthingy => simplify(subthingy));
@@ -341,8 +372,9 @@ function translatePathExpression (pathExp, translatedItems)
             }
         }
         
-        let normalElement = createAlgebraElement(Algebra.NPS, { iris: normals });
-        let invertedElement = createAlgebraElement(Algebra.INV, { path: createAlgebraElement(Algebra.NPS, { iris: inverted }) });
+        // NPS elements do not have the LINK function
+        let normalElement = createAlgebraElement(Algebra.NPS, { iris: normals.map(link => link.iri) });
+        let invertedElement = createAlgebraElement(Algebra.INV, { path: createAlgebraElement(Algebra.NPS, { iris: inverted.map(link => link.iri) }) });
         
         if (inverted.length === 0)
             res = normalElement;
@@ -450,9 +482,9 @@ function applyGraph (thingy, graph)
     if (thingy.type)
     {
         if (thingy.type === Algebra.PATTERN)
-            return Object.assign(thingy, { type: Algebra.PATTERN, graph });
+            return Object.assign(thingy, { graph });
         if (thingy.type === Algebra.PATH)
-            return Object.assign(thingy, { type: Algebra.PATH, graph });
+            return Object.assign(thingy, { graph });
         
         for (let key of Object.keys(thingy))
             thingy[key] = applyGraph(thingy[key], graph);
@@ -550,9 +582,9 @@ function translateAggregates (query, parsed, variables)
     let A = [];
     let E = [];
     if (query.group)
-        G = createAlgebraElement(Algebra.GROUP, { variables: query.group, input: res });
+        G = createAlgebraElement(Algebra.GROUP, { expressions: query.group, input: res });
     else if (containsAggregate(query.variables) || containsAggregate(query.having) || containsAggregate(query.order))
-        G = createAlgebraElement(Algebra.GROUP, { variables: [], input: res });
+        G = createAlgebraElement(Algebra.GROUP, { expressions: [], input: res });
     
     // TODO: not doing the sample stuff atm
     // TODO: more based on jena results than w3 spec (spec would require us to copy G multiple times)
@@ -564,6 +596,7 @@ function translateAggregates (query, parsed, variables)
         mapAggregates(query.order, A);
         
         // TODO: we use the jena syntax of adding aggregates as second argument to group
+        // .var will be translated later on
         G.aggregates = A.map(aggregate => { return Object.assign({var: aggregate.variable}, aggregate.object) });
         
         if (query.group)
@@ -760,6 +793,29 @@ function translateExpressionsOperations(thingy)
     
     return thingy;
 }
-// ---------------------------------- END TRANSLATE AGGREGATES ----------------------------------
+// ---------------------------------- ADD RDF.JS ----------------------------------
+
+// at this point the only remaining fields that can have a string are `type`, `symbol` (for expressions) and `separator` (damn you group_concat)
+function toRdfJs(thingy)
+{
+    if (_.isString(thingy))
+        return createTerm(thingy);
+    
+    if (_.isArray(thingy))
+        return thingy.map(toRdfJs);
+    
+    // caused by graphs already being present
+    if (thingy.termType)
+        return thingy;
+    
+    for (let key of Object.keys(thingy))
+    {
+        if (key === 'type' || key === 'symbol' || key === 'separator')
+            continue;
+        thingy[key] = toRdfJs(thingy[key]);
+    }
+    return thingy;
+}
+// ---------------------------------- END RDF.JS ----------------------------------
 
 module.exports = translate;

--- a/package-lock.json
+++ b/package-lock.json
@@ -137,11 +137,6 @@
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
       "dev": true
     },
-    "graphy": {
-      "version": "2.0.2",
-      "resolved": "http://sinopia.linkedsoftwaredependencies.org/graphy/-/graphy-2.0.2.tgz",
-      "integrity": "sha1-1977cQDwQIBMbCOUiDc3rrsXetA="
-    },
     "growl": {
       "version": "1.9.2",
       "resolved": "http://sinopia.linkedsoftwaredependencies.org/growl/-/growl-1.9.2.tgz",
@@ -326,6 +321,11 @@
       "resolved": "http://sinopia.linkedsoftwaredependencies.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
+    },
+    "n3": {
+      "version": "0.11.2",
+      "resolved": "http://sinopia.linkedsoftwaredependencies.org/n3/-/n3-0.11.2.tgz",
+      "integrity": "sha512-ICSiOmFLbZ4gI35+4H3e2vYGHDC944WZkCa1iVNRAx/mRZESEevQNFhfHaui/lhqynoZYvBVDNjM/2Tfd3TICQ=="
     },
     "once": {
       "version": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "SparqlAlgebraJS",
-  "version": "0.3.0",
+  "name": "sparqlalgebrajs",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -15,6 +15,15 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.34.tgz",
       "integrity": "sha512-Jnmm57+nHqvJUPwUzt1CLoLzFtF2B2vgG7cWFut+a4nqTp9/L6pL0N+o0Jt3V7AQnCKMsPEqQpLFZYleBCdq3w==",
       "dev": true
+    },
+    "@types/rdf-js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-1.0.1.tgz",
+      "integrity": "sha512-2uN1k9sRdV3oOvt8hHlzkJyb74JbqAHFPe8lrbYXXj5Y3JCHtzDAZyYc2x/Tyw4VWBL+mg0dEgb0VCIJiGAYFA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.0.34"
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -127,6 +136,11 @@
       "resolved": "http://sinopia.linkedsoftwaredependencies.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
       "dev": true
+    },
+    "graphy": {
+      "version": "2.0.2",
+      "resolved": "http://sinopia.linkedsoftwaredependencies.org/graphy/-/graphy-2.0.2.tgz",
+      "integrity": "sha1-1977cQDwQIBMbCOUiDc3rrsXetA="
     },
     "growl": {
       "version": "1.9.2",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "url": "https://github.com/joachimvh/SPARQLAlgebra.js"
   },
   "dependencies": {
-    "graphy": "^2.0.2",
     "lodash": "^4.13.1",
+    "n3": "^0.11.2",
     "sparqljs": "^1.5.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,12 +9,14 @@
     "url": "https://github.com/joachimvh/SPARQLAlgebra.js"
   },
   "dependencies": {
+    "graphy": "^2.0.2",
     "lodash": "^4.13.1",
     "sparqljs": "^1.5.2"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.77",
     "@types/node": "^8.0.34",
+    "@types/rdf-js": "^1.0.1",
     "mocha": "^3.5.3",
     "pre-commit": "^1.2.2",
     "typescript": "^2.5.3"

--- a/test/sparql-1.1/aggregates.js
+++ b/test/sparql-1.1/aggregates.js
@@ -325,6 +325,7 @@ describe('SPARQL 1.1 aggregates', () => {
         Util.compareAlgebras(expected, algebra);
     });
 
+    // TODO: look into this one, not directly allowed by Jena
     it('COUNT 8', () => {
         let sparql = `PREFIX : <http://www.example.org/>
                       SELECT ((?O1 + ?O2) AS ?O12) (COUNT(?O1) AS ?C)

--- a/test/sparql-1.1/exists.js
+++ b/test/sparql-1.1/exists.js
@@ -26,7 +26,7 @@ describe('SPARQL 1.1 exists', () => {
                     AE(A.GRAPH, [
                         'http://www.example.org/graph',
                         AE(A.FILTER, [
-                            AE(A.EXISTS, [ AE(A.BGP, [ T('?s', '?p', 'http://www.example.org/o2') ]) ]),
+                            AE('exists', [ AE(A.BGP, [ T('?s', '?p', 'http://www.example.org/o2') ]) ]),
                             AE(A.BGP, [ T('?s', '?p', 'http://www.example.org/o1') ])
                         ])
                     ]),
@@ -47,7 +47,7 @@ describe('SPARQL 1.1 exists', () => {
         let expected =
                 AE(A.PROJECT, [
                     AE(A.FILTER, [
-                        AE(A.EXISTS, [ AE(A.BGP, [ Util.quad('?s', '?p', 'http://www.example.org/o2', 'http://www.example.org/graph') ]) ]),
+                        AE('exists', [ AE(A.BGP, [ Util.quad('?s', '?p', 'http://www.example.org/o2', 'http://www.example.org/graph') ]) ]),
                         AE(A.BGP, [ Util.quad('?s', '?p', 'http://www.example.org/o1', 'http://www.example.org/graph') ])
                     ]),
                     [ '?s', '?p' ]
@@ -65,8 +65,8 @@ describe('SPARQL 1.1 exists', () => {
         let expected =
                 AE(A.PROJECT, [
                     AE(A.FILTER, [
-                        AE(A.EXISTS, [ AE(A.FILTER, [
-                            AE(A.EXISTS, [ AE(A.BGP, [ T('?s', '?p', 'http://www.example.org/o2') ]) ]),
+                        AE('exists', [ AE(A.FILTER, [
+                            AE('exists', [ AE(A.BGP, [ T('?s', '?p', 'http://www.example.org/o2') ]) ]),
                             AE(A.BGP, [ T('?s', '?p', 'http://www.example.org/o1') ])
                         ]) ]),
                         AE(A.BGP, [ T('?s', '?p', 'http://www.example.org/o') ])
@@ -86,8 +86,8 @@ describe('SPARQL 1.1 exists', () => {
         let expected =
                 AE(A.PROJECT, [
                     AE(A.FILTER, [
-                        AE(A.EXISTS, [ AE(A.FILTER, [
-                            AE(A.NOT_EXISTS, [ AE(A.BGP, [ T('?s', '?p', 'http://www.example.org/o2') ]) ]),
+                        AE('exists', [ AE(A.FILTER, [
+                            AE('notexists', [ AE(A.BGP, [ T('?s', '?p', 'http://www.example.org/o2') ]) ]),
                             AE(A.BGP, [ T('?s', '?p', 'http://www.example.org/o1') ]) ]) ]),
                         AE(A.BGP, [ T('?s', '?p', 'http://www.example.org/o') ])
                     ]),

--- a/test/sparql-1.1/negation.js
+++ b/test/sparql-1.1/negation.js
@@ -123,11 +123,11 @@ describe('SPARQL 1.1 negation', () => {
                                 AE(A.MINUS, [
                                     AE(A.BGP, [ T('?s2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://example/Set'),
                                                 T('?s1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://example/Set') ]),
-                                    AE(A.FILTER, [ AE(A.NOT_EXISTS, [ AE(A.BGP, [ T('?s2', 'http://example/member', '?x') ]) ]),
+                                    AE(A.FILTER, [ AE('notexists', [ AE(A.BGP, [ T('?s2', 'http://example/member', '?x') ]) ]),
                                                    AE(A.BGP, [ T('?s1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://example/Set'),
                                                                T('?s2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://example/Set'),
                                                                T('?s1', 'http://example/member', '?x') ]) ]) ]),
-                                AE(A.FILTER, [ AE(A.NOT_EXISTS, [ AE(A.BGP, [ T('?s1', 'http://example/member', '?x') ]) ]),
+                                AE(A.FILTER, [ AE('notexists', [ AE(A.BGP, [ T('?s1', 'http://example/member', '?x') ]) ]),
                                                AE(A.BGP, [ T('?s1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://example/Set'),
                                                            T('?s2', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://example/Set'),
                                                            T('?s2', 'http://example/member', '?x') ]) ]) ]) ]),
@@ -154,7 +154,7 @@ describe('SPARQL 1.1 negation', () => {
         let expected =
                 AE(A.PROJECT, [
                     AE(A.FILTER, [
-                        AE(A.NOT_EXISTS, [
+                        AE('notexists', [
                             AE(A.BGP, [ T('?otherExam', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation#PhysicalExamination'),
                                         T('?otherExam', 'http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation#follows', '?exam'),
                                         T('?otherExam', 'http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation#precedes', 'http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation#operation1') ]) ]),

--- a/test/sparql-1.1/paths.js
+++ b/test/sparql-1.1/paths.js
@@ -122,8 +122,7 @@ describe('SPARQL 1.1 paths', () => {
         let algebra = translate(sparql);
         let expected =
                 AE(A.PROJECT, [ AE(A.PATH, [ 'http://www.example.org/instance#a',
-                                                         AE(A.NPS, [ AE(A.LINK, [ 'http://www.example.org/schema#p1' ]),
-                                                                     AE(A.LINK, [ 'http://www.example.org/schema#p2' ]) ]),
+                                                         AE(A.NPS, [ 'http://www.example.org/schema#p1', 'http://www.example.org/schema#p2' ]),
                                                          '?x' ]),
                                 [ '?x' ] ]);
         Util.compareAlgebras(expected, algebra);

--- a/test/sparql-1.1/syntax.js
+++ b/test/sparql-1.1/syntax.js
@@ -47,9 +47,9 @@ describe('SPARQL 1.1 syntax', () => {
         let sparql = `SELECT * { ?s ?p ?o FILTER(?o NOT IN(1,2,?s+57)) }`;
         let algebra = translate(sparql);
         let expected =
-                AE(A.PROJECT, [ AE(A.FILTER, [ AE('notin', [ '?o', [ '"1"^^http://www.w3.org/2001/XMLSchema#integer',
-                                                                     '"2"^^http://www.w3.org/2001/XMLSchema#integer',
-                                                                     AE('+', [ '?s', '"57"^^http://www.w3.org/2001/XMLSchema#integer' ]) ] ]),
+                AE(A.PROJECT, [ AE(A.FILTER, [ AE('notin', [ '?o', '"1"^^http://www.w3.org/2001/XMLSchema#integer',
+                                                                   '"2"^^http://www.w3.org/2001/XMLSchema#integer',
+                                                                   AE('+', [ '?s', '"57"^^http://www.w3.org/2001/XMLSchema#integer' ]) ]),
                                                AE(A.BGP, [ T('?s', '?p', '?o') ]) ]),
                                 [ '?s', '?p', '?o' ] ]);
         Util.compareAlgebras(expected, algebra);
@@ -59,8 +59,7 @@ describe('SPARQL 1.1 syntax', () => {
         let sparql = `SELECT * { ?s ?p ?o FILTER(?o IN(1,<x:x>)) }`;
         let algebra = translate(sparql);
         let expected =
-                AE(A.PROJECT, [ AE(A.FILTER, [ AE('in', [ '?o', [ '"1"^^http://www.w3.org/2001/XMLSchema#integer',
-                                                                  'x:x' ] ]),
+                AE(A.PROJECT, [ AE(A.FILTER, [ AE('in', [ '?o', '"1"^^http://www.w3.org/2001/XMLSchema#integer', 'x:x' ]),
                                                AE(A.BGP, [ T('?s', '?p', '?o') ]) ]),
                                 [ '?s', '?p', '?o' ] ]);
         Util.compareAlgebras(expected, algebra);


### PR DESCRIPTION
@rubensworks 

Is this what you wanted?

The terms don't implement the equals function required by the interfaces for simplicity (for now).
Some minor parts of the typings might still change.
Specifically how expressions can be an Expression or a Term is sort of unfortunate right now.
BGPs also contain Patterns instead of rdfjs.Quads, where Pattern is an interface combining both rdfjs.Quad and the internal Operation interface for consistency.

Also want to use this box to complain about RDF.js using `termType` and `datatype` instead of having the same casing for both.