### PR TITLE
Move internal `@types/` to `devDependencies`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "*",
-        "@types/minimist": "^1.2.1",
-        "@types/node": "^15.12.2",
         "@types/sparqljs": "^3.1.2",
         "fast-deep-equal": "^3.1.3",
         "minimist": "^1.2.5",
@@ -25,7 +23,9 @@
       },
       "devDependencies": {
         "@types/chai": "^4.2.18",
+        "@types/minimist": "^1.2.1",
         "@types/mocha": "^9.0.0",
+        "@types/node": "^15.12.2",
         "chai": "^4.3.4",
         "mocha": "^9.0.3",
         "nyc": "^15.1.0",
@@ -523,7 +523,8 @@
     "node_modules/@types/minimist": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
-      "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg=="
+      "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==",
+      "dev": true
     },
     "node_modules/@types/mocha": {
       "version": "9.0.0",
@@ -3516,7 +3517,8 @@
     "@types/minimist": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
-      "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg=="
+      "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==",
+      "dev": true
     },
     "@types/mocha": {
       "version": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,6 @@
   "bin": "./bin/sparqlalgebrajs.js",
   "dependencies": {
     "@rdfjs/types": "*",
-    "@types/minimist": "^1.2.1",
-    "@types/node": "^15.12.2",
     "@types/sparqljs": "^3.1.2",
     "fast-deep-equal": "^3.1.3",
     "minimist": "^1.2.5",
@@ -23,7 +21,9 @@
   },
   "devDependencies": {
     "@types/chai": "^4.2.18",
+    "@types/minimist": "^1.2.1",
     "@types/mocha": "^9.0.0",
+    "@types/node": "^15.12.2",
     "chai": "^4.3.4",
     "mocha": "^9.0.3",
     "nyc": "^15.1.0",

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,5 +1,4 @@
 
-import * as util from 'util';
 import {Algebra} from "../index";
 import * as LibUtil from "../lib/util";
 import Factory from "../lib/factory";


### PR DESCRIPTION
I noticed that `sparqlalgebrajs` was had a `dependency` on `@types/node` which didn't match the version of Node I was using. That sent me digging a bit, and it looks like these DefinitelyTyped packages don't need to be (non-`dev`) dependencies. Looking through the generated TypeScript declarations, the only external `import`s left are from `sparqljs`, so I believe that's the only one that needs to have its `@types/` package in the `dependencies`.