### PR TITLE
Updates sparqljs to v3.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "rdf-data-factory": "^1.1.0",
     "rdf-isomorphic": "^1.3.0",
     "rdf-string": "^1.6.0",
-    "sparqljs": "^3.5.2"
+    "sparqljs": "^3.6.1"
   },
   "devDependencies": {
     "@tsconfig/node12": "^1.0.9",


### PR DESCRIPTION
Hi! This PR upgrades `sparqljs` to version 3.6.1, which fixes https://github.com/RubenVerborgh/SPARQL.js/issues/139, which is needed for `sparqljs` (and thus `sparqlalgebrajs`) to run in Deno via Skypack's packages without modifications or import maps.