### PR TITLE
Include source map files in packed files

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,12 @@
   "files": [
     "index.js",
     "index.d.ts",
+    "index.js.map",
     "lib/**/*.js",
     "lib/**/*.d.ts",
-    "bin/**/*.js"
+    "lib/**/*.js.map",
+    "bin/**/*.js",
+    "bin/**/*.js.map"
   ],
   "main": "index.js"
 }


### PR DESCRIPTION
This fixes warnings in Webpack.

This can just be a patch update.