### PR TITLE
Correctly remove quads when joining graph blocks

### DIFF
--- a/test/algebra-blank-to-var/sparql11-query/graph-join(quads).json
+++ b/test/algebra-blank-to-var/sparql11-query/graph-join(quads).json
@@ -1,0 +1,82 @@
+{
+  "type": "project",
+  "input": {
+    "type": "join",
+    "input": [
+      {
+        "type": "filter",
+        "input": {
+          "type": "bgp",
+          "patterns": [
+            {
+              "type": "pattern",
+              "termType": "Quad",
+              "subject": {
+                "termType": "Variable",
+                "value": "s"
+              },
+              "predicate": {
+                "termType": "Variable",
+                "value": "p"
+              },
+              "object": {
+                "termType": "Variable",
+                "value": "o"
+              },
+              "graph": {
+                "termType": "NamedNode",
+                "value": "http://graph.example.com/"
+              }
+            }
+          ]
+        },
+        "expression": {
+          "type": "expression",
+          "expressionType": "operator",
+          "operator": "uri",
+          "args": [
+            {
+              "type": "expression",
+              "expressionType": "term",
+              "term": {
+                "termType": "Variable",
+                "value": "s"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "type": "bgp",
+        "patterns": [
+          {
+            "type": "pattern",
+            "termType": "Quad",
+            "subject": {
+              "termType": "Variable",
+              "value": "s"
+            },
+            "predicate": {
+              "termType": "Variable",
+              "value": "p"
+            },
+            "object": {
+              "termType": "Variable",
+              "value": "o"
+            },
+            "graph": {
+              "termType": "NamedNode",
+              "value": "http://other.example.com/"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "variables": [
+    {
+      "termType": "Variable",
+      "value": "s"
+    }
+  ]
+}

--- a/test/algebra-blank-to-var/sparql11-query/graph-join.json
+++ b/test/algebra-blank-to-var/sparql11-query/graph-join.json
@@ -1,0 +1,96 @@
+{
+  "type": "project",
+  "input": {
+    "type": "join",
+    "input": [
+      {
+        "type": "graph",
+        "input": {
+          "type": "filter",
+          "input": {
+            "type": "bgp",
+            "patterns": [
+              {
+                "type": "pattern",
+                "termType": "Quad",
+                "subject": {
+                  "termType": "Variable",
+                  "value": "s"
+                },
+                "predicate": {
+                  "termType": "Variable",
+                  "value": "p"
+                },
+                "object": {
+                  "termType": "Variable",
+                  "value": "o"
+                },
+                "graph": {
+                  "termType": "DefaultGraph",
+                  "value": ""
+                }
+              }
+            ]
+          },
+          "expression": {
+            "type": "expression",
+            "expressionType": "operator",
+            "operator": "uri",
+            "args": [
+              {
+                "type": "expression",
+                "expressionType": "term",
+                "term": {
+                  "termType": "Variable",
+                  "value": "s"
+                }
+              }
+            ]
+          }
+        },
+        "name": {
+          "termType": "NamedNode",
+          "value": "http://graph.example.com/"
+        }
+      },
+      {
+        "type": "graph",
+        "input": {
+          "type": "bgp",
+          "patterns": [
+            {
+              "type": "pattern",
+              "termType": "Quad",
+              "subject": {
+                "termType": "Variable",
+                "value": "s"
+              },
+              "predicate": {
+                "termType": "Variable",
+                "value": "p"
+              },
+              "object": {
+                "termType": "Variable",
+                "value": "o"
+              },
+              "graph": {
+                "termType": "DefaultGraph",
+                "value": ""
+              }
+            }
+          ]
+        },
+        "name": {
+          "termType": "NamedNode",
+          "value": "http://other.example.com/"
+        }
+      }
+    ]
+  },
+  "variables": [
+    {
+      "termType": "Variable",
+      "value": "s"
+    }
+  ]
+}

--- a/test/algebra/sparql11-query/graph-join(quads).json
+++ b/test/algebra/sparql11-query/graph-join(quads).json
@@ -1,0 +1,82 @@
+{
+  "type": "project",
+  "input": {
+    "type": "join",
+    "input": [
+      {
+        "type": "filter",
+        "input": {
+          "type": "bgp",
+          "patterns": [
+            {
+              "type": "pattern",
+              "termType": "Quad",
+              "subject": {
+                "termType": "Variable",
+                "value": "s"
+              },
+              "predicate": {
+                "termType": "Variable",
+                "value": "p"
+              },
+              "object": {
+                "termType": "Variable",
+                "value": "o"
+              },
+              "graph": {
+                "termType": "NamedNode",
+                "value": "http://graph.example.com/"
+              }
+            }
+          ]
+        },
+        "expression": {
+          "type": "expression",
+          "expressionType": "operator",
+          "operator": "uri",
+          "args": [
+            {
+              "type": "expression",
+              "expressionType": "term",
+              "term": {
+                "termType": "Variable",
+                "value": "s"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "type": "bgp",
+        "patterns": [
+          {
+            "type": "pattern",
+            "termType": "Quad",
+            "subject": {
+              "termType": "Variable",
+              "value": "s"
+            },
+            "predicate": {
+              "termType": "Variable",
+              "value": "p"
+            },
+            "object": {
+              "termType": "Variable",
+              "value": "o"
+            },
+            "graph": {
+              "termType": "NamedNode",
+              "value": "http://other.example.com/"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "variables": [
+    {
+      "termType": "Variable",
+      "value": "s"
+    }
+  ]
+}

--- a/test/algebra/sparql11-query/graph-join.json
+++ b/test/algebra/sparql11-query/graph-join.json
@@ -1,0 +1,96 @@
+{
+  "type": "project",
+  "input": {
+    "type": "join",
+    "input": [
+      {
+        "type": "graph",
+        "input": {
+          "type": "filter",
+          "input": {
+            "type": "bgp",
+            "patterns": [
+              {
+                "type": "pattern",
+                "termType": "Quad",
+                "subject": {
+                  "termType": "Variable",
+                  "value": "s"
+                },
+                "predicate": {
+                  "termType": "Variable",
+                  "value": "p"
+                },
+                "object": {
+                  "termType": "Variable",
+                  "value": "o"
+                },
+                "graph": {
+                  "termType": "DefaultGraph",
+                  "value": ""
+                }
+              }
+            ]
+          },
+          "expression": {
+            "type": "expression",
+            "expressionType": "operator",
+            "operator": "uri",
+            "args": [
+              {
+                "type": "expression",
+                "expressionType": "term",
+                "term": {
+                  "termType": "Variable",
+                  "value": "s"
+                }
+              }
+            ]
+          }
+        },
+        "name": {
+          "termType": "NamedNode",
+          "value": "http://graph.example.com/"
+        }
+      },
+      {
+        "type": "graph",
+        "input": {
+          "type": "bgp",
+          "patterns": [
+            {
+              "type": "pattern",
+              "termType": "Quad",
+              "subject": {
+                "termType": "Variable",
+                "value": "s"
+              },
+              "predicate": {
+                "termType": "Variable",
+                "value": "p"
+              },
+              "object": {
+                "termType": "Variable",
+                "value": "o"
+              },
+              "graph": {
+                "termType": "DefaultGraph",
+                "value": ""
+              }
+            }
+          ]
+        },
+        "name": {
+          "termType": "NamedNode",
+          "value": "http://other.example.com/"
+        }
+      }
+    ]
+  },
+  "variables": [
+    {
+      "termType": "Variable",
+      "value": "s"
+    }
+  ]
+}

--- a/test/sparql/sparql11-query/graph-join(quads).sparql
+++ b/test/sparql/sparql11-query/graph-join(quads).sparql
@@ -1,0 +1,10 @@
+SELECT ?s
+WHERE {
+  GRAPH <http://graph.example.com/> {
+    ?s ?p ?o.
+    filter(uri(?s))
+  }
+  GRAPH <http://other.example.com/> {
+    ?s ?p  ?o.
+  }
+}

--- a/test/sparql/sparql11-query/graph-join.sparql
+++ b/test/sparql/sparql11-query/graph-join.sparql
@@ -1,0 +1,10 @@
+SELECT ?s
+WHERE {
+  GRAPH <http://graph.example.com/> {
+    ?s ?p ?o.
+    filter(uri(?s))
+  }
+  GRAPH <http://other.example.com/> {
+    ?s ?p  ?o.
+  }
+}


### PR DESCRIPTION
Closes https://github.com/joachimvh/SPARQLAlgebra.js/issues/102

TBH, I'm surprised this problem wasn't found earlier, because the logic used when removing quads didn't make sense in non-BGP cases. I've completely rewritten the logic there and it should be more robust now.

(Hoping this doesn't break anything new).