### PR TITLE
Correctly transform INSERT WHERE blank nodes

### DIFF
--- a/lib/sparqlAlgebra.ts
+++ b/lib/sparqlAlgebra.ts
@@ -915,8 +915,11 @@ function translateBlankNodesToVariables (res: Algebra.Operation) : Algebra.Opera
     }, {});
     return Util.mapOperation(res, {
         [Algebra.types.DELETE_INSERT]: (op: Algebra.DeleteInsert) => {
-            // Only relevant for INSERT operations as others should never contain blank nodes
-            return { result: op, recurse: false };
+            // Make sure blank nodes remain in the INSERT block, but do update the WHERE block
+            return { 
+                result: factory.createDeleteInsert(op.delete, op.insert, op.where && translateBlankNodesToVariables(op.where)), 
+                recurse: false,
+            };
         },
         [Algebra.types.PATH]: (op: Algebra.Path, factory: Factory) => {
             return {

--- a/test/algebra-blank-to-var/sparql11-query/update/insert-blank-where(quads).json
+++ b/test/algebra-blank-to-var/sparql11-query/update/insert-blank-where(quads).json
@@ -1,0 +1,50 @@
+{
+  "type": "deleteinsert",
+  "insert": [
+    {
+      "type": "pattern",
+      "termType": "Quad",
+      "subject": {
+        "termType": "Variable",
+        "value": "class"
+      },
+      "predicate": {
+        "termType": "NamedNode",
+        "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+      },
+      "object": {
+        "termType": "NamedNode",
+        "value": "http://www.w3.org/2000/01/rdf-schema#Class"
+      },
+      "graph": {
+        "termType": "DefaultGraph",
+        "value": ""
+      }
+    }
+  ],
+  "where": {
+    "type": "bgp",
+    "patterns": [
+      {
+        "type": "pattern",
+        "termType": "Quad",
+        "subject": {
+          "termType": "Variable",
+          "value": "g_0"
+        },
+        "predicate": {
+          "termType": "NamedNode",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "object": {
+          "termType": "Variable",
+          "value": "class"
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
+        }
+      }
+    ]
+  }
+}

--- a/test/algebra/sparql11-query/update/insert-blank-where(quads).json
+++ b/test/algebra/sparql11-query/update/insert-blank-where(quads).json
@@ -1,0 +1,50 @@
+{
+  "type": "deleteinsert",
+  "insert": [
+    {
+      "type": "pattern",
+      "termType": "Quad",
+      "subject": {
+        "termType": "Variable",
+        "value": "class"
+      },
+      "predicate": {
+        "termType": "NamedNode",
+        "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+      },
+      "object": {
+        "termType": "NamedNode",
+        "value": "http://www.w3.org/2000/01/rdf-schema#Class"
+      },
+      "graph": {
+        "termType": "DefaultGraph",
+        "value": ""
+      }
+    }
+  ],
+  "where": {
+    "type": "bgp",
+    "patterns": [
+      {
+        "type": "pattern",
+        "termType": "Quad",
+        "subject": {
+          "termType": "BlankNode",
+          "value": "g_0"
+        },
+        "predicate": {
+          "termType": "NamedNode",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        "object": {
+          "termType": "Variable",
+          "value": "class"
+        },
+        "graph": {
+          "termType": "DefaultGraph",
+          "value": ""
+        }
+      }
+    ]
+  }
+}

--- a/test/sparql/sparql11-query/update/insert-blank-where(quads).sparql
+++ b/test/sparql/sparql11-query/update/insert-blank-where(quads).sparql
@@ -1,0 +1,8 @@
+prefix : <http://example.org/data#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+insert {
+    ?class a rdfs:Class .
+} where {
+    [] a ?class .
+}


### PR DESCRIPTION
Should fix https://github.com/comunica/comunica/issues/1352

All blank node conversion was disabled for INSERT/DELETE blocks to prevent changes to blank nodes in the INSERT part, but that was too much, WHERE bodies still need to change.