### PR TITLE
Correctly create variables from strings starting with '$'

### DIFF
--- a/lib/factory.ts
+++ b/lib/factory.ts
@@ -86,6 +86,10 @@ export default class Factory
 
     createTerm (str: string): RDF.Term
     {
+        console.log("creatingTerm");
+        if (str[0] === '$') {
+            str = str.replace('$', '?');
+        }
         return stringToTerm(str, this.dataFactory);
     }
 

--- a/lib/factory.ts
+++ b/lib/factory.ts
@@ -86,7 +86,6 @@ export default class Factory
 
     createTerm (str: string): RDF.Term
     {
-        console.log("creatingTerm");
         if (str[0] === '$') {
             str = str.replace('$', '?');
         }

--- a/lib/sparqlAlgebra.ts
+++ b/lib/sparqlAlgebra.ts
@@ -154,8 +154,12 @@ function findAllVariables(thingy: any): void
         for (let key of Object.keys(thingy))
         {
             // Some variables are hidden in keys (specifically for VALUES)
-            if (key.startsWith('?'))
+            if (key.startsWith('?')) {
                 variables.add(key);
+            } else if (key.startsWith('$')) {
+                variables.add(`?${key.slice(1)}`);
+            }
+
             findAllVariables(thingy[key]);
         }
     }


### PR DESCRIPTION
Hi,

In fixing [an issue in comunica](https://github.com/comunica/comunica/issues/1298) I discovered that when createTerm is called with a string that starts with '$', it doesn't create a Variable as it should. It creates a NamedNode because it calls stringToTerm which doesn't know that '$' indicates a variable.

I've implemented a fix by replacing the '$' with a '?' right before calling stringToTerm. I'm looking forward to hearing your feedback.