### PR TITLE
Put BIND requests back in query when required

### DIFF
--- a/test/algebra/sparql11-query/unused-extend.json
+++ b/test/algebra/sparql11-query/unused-extend.json
@@ -1,0 +1,99 @@
+{
+  "type": "project",
+  "input": {
+    "type": "extend",
+    "input": {
+      "type": "extend",
+      "input": {
+        "type": "bgp",
+        "patterns": [
+          {
+            "type": "pattern",
+            "termType": "Quad",
+            "subject": {
+              "termType": "Variable",
+              "value": "a"
+            },
+            "predicate": {
+              "termType": "NamedNode",
+              "value": "http://mydom#startTime"
+            },
+            "object": {
+              "termType": "Variable",
+              "value": "st"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
+            }
+          },
+          {
+            "type": "pattern",
+            "termType": "Quad",
+            "subject": {
+              "termType": "Variable",
+              "value": "a"
+            },
+            "predicate": {
+              "termType": "NamedNode",
+              "value": "http://mydom#endTime"
+            },
+            "object": {
+              "termType": "Variable",
+              "value": "et"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
+            }
+          }
+        ]
+      },
+      "variable": {
+        "termType": "Variable",
+        "value": "duration"
+      },
+      "expression": {
+        "type": "expression",
+        "expressionType": "operator",
+        "operator": "-",
+        "args": [
+          {
+            "type": "expression",
+            "expressionType": "term",
+            "term": {
+              "termType": "Variable",
+              "value": "et"
+            }
+          },
+          {
+            "type": "expression",
+            "expressionType": "term",
+            "term": {
+              "termType": "Variable",
+              "value": "st"
+            }
+          }
+        ]
+      }
+    },
+    "variable": {
+      "termType": "Variable",
+      "value": "d"
+    },
+    "expression": {
+      "type": "expression",
+      "expressionType": "term",
+      "term": {
+        "termType": "Variable",
+        "value": "duration"
+      }
+    }
+  },
+  "variables": [
+    {
+      "termType": "Variable",
+      "value": "d"
+    }
+  ]
+}

--- a/test/sparql/sparql11-query/unused-extend.sparql
+++ b/test/sparql/sparql11-query/unused-extend.sparql
@@ -1,0 +1,7 @@
+PREFIX : <http://mydom#>
+SELECT (?duration as ?d) WHERE {
+  ?a :startTime ?st;
+     :endTime ?et.
+
+  BIND( (?et - ?st) as ?duration)
+}


### PR DESCRIPTION
Closes https://github.com/joachimvh/SPARQLAlgebra.js/issues/119

Problem is that there is no way to differentiate between extends caused by the project or BIND statements at the root of a query. Currently the code forgot to put the latter ones back if they were not referenced in the project (or group by).