### PR TITLE
Update to rdf-data-factory v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node-version:
-          - 12.x
           - 14.x
           - 16.x
           - 18.x

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,13 @@
       "version": "4.3.8",
       "license": "MIT",
       "dependencies": {
-        "@rdfjs/types": "*",
         "@types/sparqljs": "^3.1.3",
         "fast-deep-equal": "^3.1.3",
         "minimist": "^1.2.6",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "rdf-terms": "^1.10.0",
+        "rdf-data-factory": "^2.0.1",
+        "rdf-isomorphic": "^2.0.0",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0",
         "sparqljs": "^3.7.1"
       },
       "bin": {
@@ -950,9 +949,10 @@
       }
     },
     "node_modules/@rdfjs/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-YxVkH0XrCNG3MWeZxfg596GFe+oorTVusmNxRP6ZHTsGczZ8AGvG3UchRNkg3Fy4MyysI7vBAA5YZbESL+VmHQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-bHIjRZ6wuQQY/47dKfGI9fCs9/gs83IgHnoPsAgEIj/ASFTl3Eo4SWIPMC0F1B0LqhrapQb1HaakuD6ikpTDEQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -3243,22 +3243,31 @@
       "dev": true
     },
     "node_modules/rdf-data-factory": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.2.tgz",
-      "integrity": "sha512-TfQD63Lokabd09ES1jAtKK8AA6rkr9rwyUBGo6olOt1CE0Um36CUQIqytyf0am2ouBPR0l7SaHxCiMcPGHkt1A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.1.tgz",
+      "integrity": "sha512-qpCmbtuCjdH5I2vnn+RpdAcWr32RKOv0ATKM4A2Df+d4yRk1YWiBnAY/S6ndxxY90bb5Ig9458I6Tlytozu5eg==",
+      "license": "MIT",
       "dependencies": {
-        "@rdfjs/types": "*"
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
       }
     },
     "node_modules/rdf-isomorphic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-1.3.0.tgz",
-      "integrity": "sha512-3BRwUwCNHHR8//bqmVH+knTFVbVfkp7CWyQk7qPHHA8JriXBYxrab21OomjJx/2KF21w8bWz344mgNYEaQABYQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-2.0.0.tgz",
+      "integrity": "sha512-fa3E8Nbi9qCzMh7TXMW+RVvP3gfGpNWlXocuC43OFLlX+2j0kdhlwDv2Y9jFQYUqeYeywBQYM0cuphD+Oi3PHg==",
+      "license": "MIT",
       "dependencies": {
-        "@rdfjs/types": "*",
         "hash.js": "^1.1.7",
-        "rdf-string": "^1.6.0",
-        "rdf-terms": "^1.7.0"
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
       }
     },
     "node_modules/rdf-js": {
@@ -3270,22 +3279,30 @@
       }
     },
     "node_modules/rdf-string": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.0.tgz",
-      "integrity": "sha512-6vQVlEobIHralPtx8V9vtgxA+fwnzZjZv6lRz8dfymILZF6Fl3QJwyRaOAvYaUQc1JMmshGI/wlYlaxin2AldQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-2.0.0.tgz",
+      "integrity": "sha512-qxhoVZahUlRuWw1XPwwkT6W1syFNhtoexZDy139FaEyMDEJSiOMaffCe3pgEyBYapnOGDvHjL/zR1D+I8a9vAg==",
+      "license": "MIT",
       "dependencies": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0"
+        "rdf-data-factory": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
       }
     },
     "node_modules/rdf-terms": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-1.10.0.tgz",
-      "integrity": "sha512-7arMnF4ds8SySRE59VkOmx528YBi1KyZn2NEZJZmvcwh48u4z2zG8VBKQ+XAQtWbmaI4jSDcu5UmuSh6ogVMlg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-2.0.0.tgz",
+      "integrity": "sha512-9O+ifVcvY4ZktOr+uXKswoOV6airAsIKeqCr+C47kFZBB8X+NyPSqDRGgI6X+je8It6z2e9jZhWwjJiEZ8Yn5Q==",
+      "license": "MIT",
       "dependencies": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-string": "^1.6.0"
+        "rdf-data-factory": "^2.0.0",
+        "rdf-string": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
       }
     },
     "node_modules/react-is": {
@@ -3468,6 +3485,24 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/sparqljs/node_modules/@rdfjs/types": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
+      "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/sparqljs/node_modules/rdf-data-factory": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
+      "integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^1.0.0"
       }
     },
     "node_modules/spawn-sync": {
@@ -4635,9 +4670,9 @@
       }
     },
     "@rdfjs/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-YxVkH0XrCNG3MWeZxfg596GFe+oorTVusmNxRP6ZHTsGczZ8AGvG3UchRNkg3Fy4MyysI7vBAA5YZbESL+VmHQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-bHIjRZ6wuQQY/47dKfGI9fCs9/gs83IgHnoPsAgEIj/ASFTl3Eo4SWIPMC0F1B0LqhrapQb1HaakuD6ikpTDEQ==",
       "requires": {
         "@types/node": "*"
       }
@@ -6419,22 +6454,21 @@
       "dev": true
     },
     "rdf-data-factory": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.2.tgz",
-      "integrity": "sha512-TfQD63Lokabd09ES1jAtKK8AA6rkr9rwyUBGo6olOt1CE0Um36CUQIqytyf0am2ouBPR0l7SaHxCiMcPGHkt1A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.1.tgz",
+      "integrity": "sha512-qpCmbtuCjdH5I2vnn+RpdAcWr32RKOv0ATKM4A2Df+d4yRk1YWiBnAY/S6ndxxY90bb5Ig9458I6Tlytozu5eg==",
       "requires": {
-        "@rdfjs/types": "*"
+        "@rdfjs/types": "^2.0.0"
       }
     },
     "rdf-isomorphic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-1.3.0.tgz",
-      "integrity": "sha512-3BRwUwCNHHR8//bqmVH+knTFVbVfkp7CWyQk7qPHHA8JriXBYxrab21OomjJx/2KF21w8bWz344mgNYEaQABYQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-2.0.0.tgz",
+      "integrity": "sha512-fa3E8Nbi9qCzMh7TXMW+RVvP3gfGpNWlXocuC43OFLlX+2j0kdhlwDv2Y9jFQYUqeYeywBQYM0cuphD+Oi3PHg==",
       "requires": {
-        "@rdfjs/types": "*",
         "hash.js": "^1.1.7",
-        "rdf-string": "^1.6.0",
-        "rdf-terms": "^1.7.0"
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0"
       }
     },
     "rdf-js": {
@@ -6446,22 +6480,20 @@
       }
     },
     "rdf-string": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.0.tgz",
-      "integrity": "sha512-6vQVlEobIHralPtx8V9vtgxA+fwnzZjZv6lRz8dfymILZF6Fl3QJwyRaOAvYaUQc1JMmshGI/wlYlaxin2AldQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-2.0.0.tgz",
+      "integrity": "sha512-qxhoVZahUlRuWw1XPwwkT6W1syFNhtoexZDy139FaEyMDEJSiOMaffCe3pgEyBYapnOGDvHjL/zR1D+I8a9vAg==",
       "requires": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0"
+        "rdf-data-factory": "^2.0.0"
       }
     },
     "rdf-terms": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-1.10.0.tgz",
-      "integrity": "sha512-7arMnF4ds8SySRE59VkOmx528YBi1KyZn2NEZJZmvcwh48u4z2zG8VBKQ+XAQtWbmaI4jSDcu5UmuSh6ogVMlg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-2.0.0.tgz",
+      "integrity": "sha512-9O+ifVcvY4ZktOr+uXKswoOV6airAsIKeqCr+C47kFZBB8X+NyPSqDRGgI6X+je8It6z2e9jZhWwjJiEZ8Yn5Q==",
       "requires": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-string": "^1.6.0"
+        "rdf-data-factory": "^2.0.0",
+        "rdf-string": "^2.0.0"
       }
     },
     "react-is": {
@@ -6599,6 +6631,24 @@
       "integrity": "sha512-I1jYMtcwDkgCEqQ4eQuQIhB8hFAlRAJ6YDXDcV54XztaJaYRFqJlidHt77S3j8Mfh6kY6GK04dXPEIopxbEeuQ==",
       "requires": {
         "rdf-data-factory": "^1.1.2"
+      },
+      "dependencies": {
+        "@rdfjs/types": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
+          "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "rdf-data-factory": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
+          "integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
+          "requires": {
+            "@rdfjs/types": "^1.0.0"
+          }
+        }
       }
     },
     "spawn-sync": {

--- a/package.json
+++ b/package.json
@@ -15,14 +15,13 @@
     "test": "jest"
   },
   "dependencies": {
-    "@rdfjs/types": "*",
     "@types/sparqljs": "^3.1.3",
     "fast-deep-equal": "^3.1.3",
     "minimist": "^1.2.6",
-    "rdf-data-factory": "^1.1.0",
-    "rdf-isomorphic": "^1.3.0",
-    "rdf-string": "^1.6.0",
-    "rdf-terms": "^1.10.0",
+    "rdf-data-factory": "^2.0.1",
+    "rdf-isomorphic": "^2.0.0",
+    "rdf-string": "^2.0.0",
+    "rdf-terms": "^2.0.0",
     "sparqljs": "^3.7.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This includes a bump to @rdfjs/types@2.0.0 (among other things, it adds support for base directions for RDF 1.2),
which requires TypeScript 5 and Node 14+.

**When merged, this should be released as a new major version.** (it's what I'm doing in all of my other libs right now as well)