### PR TITLE
Fix blank nodes in triple terms not being converted to variables

### DIFF
--- a/lib/sparqlAlgebra.ts
+++ b/lib/sparqlAlgebra.ts
@@ -920,8 +920,8 @@ function translateBlankNodesToVariables (res: Algebra.Operation) : Algebra.Opera
     return Util.mapOperation(res, {
         [Algebra.types.DELETE_INSERT]: (op: Algebra.DeleteInsert) => {
             // Make sure blank nodes remain in the INSERT block, but do update the WHERE block
-            return { 
-                result: factory.createDeleteInsert(op.delete, op.insert, op.where && translateBlankNodesToVariables(op.where)), 
+            return {
+                result: factory.createDeleteInsert(op.delete, op.insert, op.where && translateBlankNodesToVariables(op.where)),
                 recurse: false,
             };
         },
@@ -966,6 +966,14 @@ function translateBlankNodesToVariables (res: Algebra.Operation) : Algebra.Opera
                 blankToVariableMapping[term.value] = variable;
             }
             return variable;
+        }
+        if (term.termType === 'Quad') {
+            return factory.dataFactory.quad(
+              blankToVariable(term.subject),
+              blankToVariable(term.predicate),
+              blankToVariable(term.object),
+              blankToVariable(term.graph),
+            );
         }
         return term;
   }

--- a/test/algebra-blank-to-var/sparqlstar-annotated/sparql-star-annotated-1.json
+++ b/test/algebra-blank-to-var/sparqlstar-annotated/sparql-star-annotated-1.json
@@ -142,7 +142,7 @@
           "type": "pattern",
           "termType": "Quad",
           "subject": {
-            "termType": "BlankNode",
+            "termType": "Variable",
             "value": "e_b"
           },
           "predicate": {

--- a/test/algebra-blank-to-var/sparqlstar-annotated/sparql-star-annotated-list-object.json
+++ b/test/algebra-blank-to-var/sparqlstar-annotated/sparql-star-annotated-list-object.json
@@ -38,7 +38,7 @@
             "value": "http://example.com/ns#p"
           },
           "object": {
-            "termType": "BlankNode",
+            "termType": "Variable",
             "value": "g_0"
           },
           "graph": {

--- a/test/algebra-blank-to-var/sparqlstar-annotated/sparql-star-annotated-list-subject.json
+++ b/test/algebra-blank-to-var/sparqlstar-annotated/sparql-star-annotated-list-subject.json
@@ -30,7 +30,7 @@
           "type": "pattern",
           "termType": "Quad",
           "subject": {
-            "termType": "BlankNode",
+            "termType": "Variable",
             "value": "g_0"
           },
           "predicate": {

--- a/test/algebra-blank-to-var/sparqlstar-spec/sparql-star-syntax-bnode-01.json
+++ b/test/algebra-blank-to-var/sparqlstar-spec/sparql-star-syntax-bnode-01.json
@@ -10,7 +10,7 @@
           "type": "pattern",
           "termType": "Quad",
           "subject": {
-            "termType": "BlankNode",
+            "termType": "Variable",
             "value": "e_a"
           },
           "predicate": {

--- a/test/algebra-blank-to-var/sparqlstar-spec/sparql-star-syntax-bnode-02.json
+++ b/test/algebra-blank-to-var/sparqlstar-spec/sparql-star-syntax-bnode-02.json
@@ -18,7 +18,7 @@
             "value": "http://example.com/ns#p"
           },
           "object": {
-            "termType": "BlankNode",
+            "termType": "Variable",
             "value": "e_a"
           },
           "graph": {

--- a/test/algebra-blank-to-var/sparqlstar-spec/sparql-star-syntax-bnode-03.json
+++ b/test/algebra-blank-to-var/sparqlstar-spec/sparql-star-syntax-bnode-03.json
@@ -10,7 +10,7 @@
           "type": "pattern",
           "termType": "Quad",
           "subject": {
-            "termType": "BlankNode",
+            "termType": "Variable",
             "value": "g_0"
           },
           "predicate": {
@@ -18,7 +18,7 @@
             "value": "http://example.com/ns#p"
           },
           "object": {
-            "termType": "BlankNode",
+            "termType": "Variable",
             "value": "g_1"
           },
           "graph": {

--- a/test/algebra-blank-to-var/sparqlstar-spec/sparql-star-syntax-compound.json
+++ b/test/algebra-blank-to-var/sparqlstar-spec/sparql-star-syntax-compound.json
@@ -97,7 +97,7 @@
               "value": "http://example.com/ns#b"
             },
             "object": {
-              "termType": "BlankNode",
+              "termType": "Variable",
               "value": "g_0"
             },
             "graph": {
@@ -121,7 +121,7 @@
             "type": "pattern",
             "termType": "Quad",
             "subject": {
-              "termType": "BlankNode",
+              "termType": "Variable",
               "value": "g_1"
             },
             "predicate": {
@@ -153,7 +153,7 @@
               "value": "http://example.com/ns#b"
             },
             "object": {
-              "termType": "BlankNode",
+              "termType": "Variable",
               "value": "g_2"
             },
             "graph": {


### PR DESCRIPTION
A small fix necessary to fix Comunica issues discovered in SPARQL 1.2 spec tests.